### PR TITLE
Updated hackathon oracle addresses from script

### DIFF
--- a/docs/hackathons/eth-lisbon-hackathon.md
+++ b/docs/hackathons/eth-lisbon-hackathon.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # ETH Lisbon Hackathon Guide
 
-![ETH Lisbon Hackathon](<https://pbs.twimg.com/media/F43NCzgWMAAiQNi?format=png&name=large>)
+![ETH Lisbon Hackathon](https://pbs.twimg.com/media/F43NCzgWMAAiQNi?format=png&name=large)
 
 Welcome to the ETH Lisbon Hackathon! This document serves as a guide for integrating Chronicle Oracles into your hackathon projects. Our team is here to assist you.
 
@@ -39,6 +39,7 @@ For any inquiries, feel free to reach out at our booth, join our [Discord](https
 **Description:** Two teams will be awarded for integrating one or more Chronicle Oracles in a project built on Polygon zkEVM testnet. 'DeFi' and 'Public Good' projects are preferred. The Oracle integration must be integral to the operation of the build to be considered. Please see the Chronicle ETH Lisbon Hackathon Docs for a complete list of available Oracles.
 
 **Reward:** $1000 ($500 from Chronicle/$500 from Polygon).<br/>
+
 - 1st Prize: $600 <br/>
 - 2nd Prize: $400 <br/>
 
@@ -146,91 +147,101 @@ That should send you a popup message on your wallet to sign. Once signed, it sho
 | Contract Name | Contract Address on Sepolia network                                                                                                |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Self-kisser   | [0x0Dcc19657007713483A5cA76e6A7bbe5f56EA37d](https://sepolia.etherscan.io/address/0x0Dcc19657007713483A5cA76e6A7bbe5f56EA37d#code) |
-| ETH/USD       | [0xc8A1F9461115EF3C1E84Da6515A88Ea49CA97660](https://sepolia.etherscan.io/address/0xc8A1F9461115EF3C1E84Da6515A88Ea49CA97660#code) |
-| AAVE/USD      | [0xa38C2B5408Eb1DCeeDBEC5d61BeD580589C6e717](https://sepolia.etherscan.io/address/0xa38C2B5408Eb1DCeeDBEC5d61BeD580589C6e717#code) |
-| ARB/USD       | [0x579BfD0581beD0d18fBb0Ebab099328d451552DD](https://sepolia.etherscan.io/address/0x579BfD0581beD0d18fBb0Ebab099328d451552DD#code) |
-| AVAX/USD      | [0x78C8260AF7C8D0d17Cf3BA91F251E9375A389688](https://sepolia.etherscan.io/address/0x78C8260AF7C8D0d17Cf3BA91F251E9375A389688#code) |
-| BNB/USD       | [0x26EE3E8b618227C1B735D8D884d52A852410019f](https://sepolia.etherscan.io/address/0x26EE3E8b618227C1B735D8D884d52A852410019f#code) |
-| BTC/USD       | [0x4B5aBFC0Fe78233b97C80b8410681765ED9fC29c](https://sepolia.etherscan.io/address/0x4B5aBFC0Fe78233b97C80b8410681765ED9fC29c#code) |
-| CRV/USD       | [0xf29a932ae56bB96CcACF8d1f2Da9028B01c8F030](https://sepolia.etherscan.io/address/0xf29a932ae56bB96CcACF8d1f2Da9028B01c8F030#code) |
-| DAI/USD       | [0xa7aA6a860D17A89810dE6e6278c58EB21Fa00fc4](https://sepolia.etherscan.io/address/0xa7aA6a860D17A89810dE6e6278c58EB21Fa00fc4#code) |
-| ETH/BTC       | [0x1804969b296E89C1ddB1712fA99816446956637e](https://sepolia.etherscan.io/address/0x1804969b296E89C1ddB1712fA99816446956637e#code) |
-| GNO/USD       | [0xA28dCaB66FD25c668aCC7f232aa71DA1943E04b8](https://sepolia.etherscan.io/address/0xA28dCaB66FD25c668aCC7f232aa71DA1943E04b8#code) |
-| IBTA/USD      | [0x07487b0Bf28801ECD15BF09C13e32FBc87572e81](https://sepolia.etherscan.io/address/0x07487b0Bf28801ECD15BF09C13e32FBc87572e81#code) |
-| LDO/USD       | [0xa53dc5B100f0e4aB593f2D8EcD3c5932EE38215E](https://sepolia.etherscan.io/address/0xa53dc5B100f0e4aB593f2D8EcD3c5932EE38215E#code) |
-| LINK/USD      | [0xecB89B57A60ac44E06ab1B767947c19b236760c3](https://sepolia.etherscan.io/address/0xecB89B57A60ac44E06ab1B767947c19b236760c3#code) |
-| MATIC/USD     | [0xa48c56e48A71966676d0D113EAEbe6BE61661F18](https://sepolia.etherscan.io/address/0xa48c56e48A71966676d0D113EAEbe6BE61661F18#code) |
-| MKR/USD       | [0x67ffF0C6abD2a36272870B1E8FE42CC8E8D5ec4d](https://sepolia.etherscan.io/address/0x67ffF0C6abD2a36272870B1E8FE42CC8E8D5ec4d#code) |
-| OP/USD        | [0xfadF055f6333a4ab435D2D248aEe6617345A4782](https://sepolia.etherscan.io/address/0xfadF055f6333a4ab435D2D248aEe6617345A4782#code) |
-| RETH/USD      | [0xEE02370baC10b3AC3f2e9eebBf8f3feA1228D263](https://sepolia.etherscan.io/address/0xEE02370baC10b3AC3f2e9eebBf8f3feA1228D263#code) |
-| SDAI/DAI      | [0xD93c56Aa71923228cDbE2be3bf5a83bF25B0C491](https://sepolia.etherscan.io/address/0xD93c56Aa71923228cDbE2be3bf5a83bF25B0C491#code) |
-| SNX/USD       | [0xD20f1eC72bA46b6126F96c5a91b6D3372242cE98](https://sepolia.etherscan.io/address/0xD20f1eC72bA46b6126F96c5a91b6D3372242cE98#code) |
-| SOL/USD       | [0x4D1e6f39bbfcce8b471171b8431609b83f3a096D](https://sepolia.etherscan.io/address/0x4D1e6f39bbfcce8b471171b8431609b83f3a096D#code) |
-| UNI/USD       | [0x2aFF768F5d6FC63fA456B062e02f2049712a1ED5](https://sepolia.etherscan.io/address/0x2aFF768F5d6FC63fA456B062e02f2049712a1ED5#code) |
-| USDC/USD      | [0x1173da1811a311234e7Ab0A33B4B7B646Ff42aEC](https://sepolia.etherscan.io/address/0x1173da1811a311234e7Ab0A33B4B7B646Ff42aEC#code) |
-| USDT/USD      | [0x0bd446021Ab95a2ABd638813f9bDE4fED3a5779a](https://sepolia.etherscan.io/address/0x0bd446021Ab95a2ABd638813f9bDE4fED3a5779a#code) |
-| WBTC/USD      | [0xA7226d85CE5F0DE97DCcBDBfD38634D6391d0584](https://sepolia.etherscan.io/address/0xA7226d85CE5F0DE97DCcBDBfD38634D6391d0584#code) |
-| WSTETH/USD    | [0xc9Bb81d3668f03ec9109bBca77d32423DeccF9Ab](https://sepolia.etherscan.io/address/0xc9Bb81d3668f03ec9109bBca77d32423DeccF9Ab#code) |
-| YFI/USD       | [0x0893EcE705639112C1871DcE88D87D81540D0199](https://sepolia.etherscan.io/address/0x0893EcE705639112C1871DcE88D87D81540D0199#code) |
+| AAVE/USD      | [0xED4C91FC28B48E2Cf98b59668408EAeE44665511](https://sepolia.etherscan.io/address/0xED4C91FC28B48E2Cf98b59668408EAeE44665511#code) |
+| ARB/USD       | [0x7dE6Df8E4c057eD9baE215F347A0339D603B09B2](https://sepolia.etherscan.io/address/0x7dE6Df8E4c057eD9baE215F347A0339D603B09B2#code) |
+| AVAX/USD      | [0xD419f76594d411BD94c71FB0a78c80f71A2290Ce](https://sepolia.etherscan.io/address/0xD419f76594d411BD94c71FB0a78c80f71A2290Ce#code) |
+| BNB/USD       | [0x6931FB9C54958f77873ceC4536EaC56F561d2dC4](https://sepolia.etherscan.io/address/0x6931FB9C54958f77873ceC4536EaC56F561d2dC4#code) |
+| BTC/USD       | [0xdD5232e76798BEACB69eC310d9b0864b56dD08dD](https://sepolia.etherscan.io/address/0xdD5232e76798BEACB69eC310d9b0864b56dD08dD#code) |
+| CRV/USD       | [0x7B6E473f1CeB8b7100C9F7d58879e7211Bc48f32](https://sepolia.etherscan.io/address/0x7B6E473f1CeB8b7100C9F7d58879e7211Bc48f32#code) |
+| DAI/USD       | [0x16984396EE0903782Ba8e6ebfA7DD356B0cA3841](https://sepolia.etherscan.io/address/0x16984396EE0903782Ba8e6ebfA7DD356B0cA3841#code) |
+| ETH/BTC       | [0x4E866Ac929374096Afc2715C4e9c40D581A4067e](https://sepolia.etherscan.io/address/0x4E866Ac929374096Afc2715C4e9c40D581A4067e#code) |
+| ETH/USD       | [0x90430C5b8045a1E2A0Fc4e959542a0c75b576439](https://sepolia.etherscan.io/address/0x90430C5b8045a1E2A0Fc4e959542a0c75b576439#code) |
+| GNO/USD       | [0xBcC6BFFde7888A3008f17c88D5a5e5F0D7462cf9](https://sepolia.etherscan.io/address/0xBcC6BFFde7888A3008f17c88D5a5e5F0D7462cf9#code) |
+| IBTA/USD      | [0xc52539EfbA58a521d69494D86fc47b9E71D32997](https://sepolia.etherscan.io/address/0xc52539EfbA58a521d69494D86fc47b9E71D32997#code) |
+| LDO/USD       | [0x3aeF92049C9401094A9f75259430F4771143F0C3](https://sepolia.etherscan.io/address/0x3aeF92049C9401094A9f75259430F4771143F0C3#code) |
+| LINK/USD      | [0x4EDdF05CfAd20f1E39ed4CB067bdfa831dAeA9fE](https://sepolia.etherscan.io/address/0x4EDdF05CfAd20f1E39ed4CB067bdfa831dAeA9fE#code) |
+| MATIC/USD     | [0x06997AadB30d51eAdBAA7836f7a0F177474fc235](https://sepolia.etherscan.io/address/0x06997AadB30d51eAdBAA7836f7a0F177474fc235#code) |
+| MKR/USD       | [0xE61A66f737c32d5Ac8cDea6982635B80447e9404](https://sepolia.etherscan.io/address/0xE61A66f737c32d5Ac8cDea6982635B80447e9404#code) |
+| OP/USD        | [0x1Ae491D618A667a44D48E0b0BE2Cc0cDBF269BC5](https://sepolia.etherscan.io/address/0x1Ae491D618A667a44D48E0b0BE2Cc0cDBF269BC5#code) |
+| RETH/USD      | [0xEff79d34f24Bb36eD8FB6c4CbaD5De293fdCf66F](https://sepolia.etherscan.io/address/0xEff79d34f24Bb36eD8FB6c4CbaD5De293fdCf66F#code) |
+| SDAI/DAI      | [0xB6EE756124e88e12585981DdDa9E6E3bf3C4487D](https://sepolia.etherscan.io/address/0xB6EE756124e88e12585981DdDa9E6E3bf3C4487D#code) |
+| SNX/USD       | [0x6Ab51f7E684923CE051e784D382A470b0fa834Be](https://sepolia.etherscan.io/address/0x6Ab51f7E684923CE051e784D382A470b0fa834Be#code) |
+| SOL/USD       | [0x11ceEcca4d49f596E0Df781Af237CDE741ad2106](https://sepolia.etherscan.io/address/0x11ceEcca4d49f596E0Df781Af237CDE741ad2106#code) |
+| UNI/USD       | [0xfE051Bc90D3a2a825fA5172181f9124f8541838c](https://sepolia.etherscan.io/address/0xfE051Bc90D3a2a825fA5172181f9124f8541838c#code) |
+| USDC/USD      | [0xfef7a1Eb17A095E1bd7723cBB1092caba34f9b1C](https://sepolia.etherscan.io/address/0xfef7a1Eb17A095E1bd7723cBB1092caba34f9b1C#code) |
+| USDT/USD      | [0xF78A4e093Cd2D9F57Bb363Cc4edEBcf9bF3325ba](https://sepolia.etherscan.io/address/0xF78A4e093Cd2D9F57Bb363Cc4edEBcf9bF3325ba#code) |
+| WBTC/USD      | [0x39C899178F4310705b12888886884b361CeF26C7](https://sepolia.etherscan.io/address/0x39C899178F4310705b12888886884b361CeF26C7#code) |
+| WSTETH/ETH    | [0x67E93d37B57747686F22f2F2f0a8aAd253199B38](https://sepolia.etherscan.io/address/0x67E93d37B57747686F22f2F2f0a8aAd253199B38#code) |
+| WSTETH/USD    | [0x8Ba43F8Fa2fC13D7EEDCeb9414CDbB6643483C34](https://sepolia.etherscan.io/address/0x8Ba43F8Fa2fC13D7EEDCeb9414CDbB6643483C34#code) |
+| YFI/USD       | [0x16978358A8D6C7C8cA758F433685A5E8D988dfD4](https://sepolia.etherscan.io/address/0x16978358A8D6C7C8cA758F433685A5E8D988dfD4#code) |
 
 ## Smart Contract Addresses on Polygon zkEVM Testnet
 
-| Contract Name | Contract Address on zkEVM Testnet                                                                                                   |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Contract Name | Contract Address on zkEVM Testnet                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | Self-kisser   | [0x0Dcc19657007713483A5cA76e6A7bbe5f56EA37d](https://testnet-zkevm.polygonscan.com/address/0x0Dcc19657007713483A5cA76e6A7bbe5f56EA37d#code) |
-| AAVE/USD       | [0xED4C91FC28B48E2Cf98b59668408EAeE44665511](https://testnet-zkevm.polygonscan.com/address/0xED4C91FC28B48E2Cf98b59668408EAeE44665511#code) |
-| ARB/USD      | [0x7dE6Df8E4c057eD9baE215F347A0339D603B09B2](https://testnet-zkevm.polygonscan.com/address/0x7dE6Df8E4c057eD9baE215F347A0339D603B09B2#code) |
+| AAVE/USD      | [0xED4C91FC28B48E2Cf98b59668408EAeE44665511](https://testnet-zkevm.polygonscan.com/address/0xED4C91FC28B48E2Cf98b59668408EAeE44665511#code) |
+| ARB/USD       | [0x7dE6Df8E4c057eD9baE215F347A0339D603B09B2](https://testnet-zkevm.polygonscan.com/address/0x7dE6Df8E4c057eD9baE215F347A0339D603B09B2#code) |
+| AVAX/USD      | [0xD419f76594d411BD94c71FB0a78c80f71A2290Ce](https://testnet-zkevm.polygonscan.com/address/0xD419f76594d411BD94c71FB0a78c80f71A2290Ce#code) |
 | BNB/USD       | [0x6931FB9C54958f77873ceC4536EaC56F561d2dC4](https://testnet-zkevm.polygonscan.com/address/0x6931FB9C54958f77873ceC4536EaC56F561d2dC4#code) |
-| CRV/USD     | [0x7B6E473f1CeB8b7100C9F7d58879e7211Bc48f32](https://testnet-zkevm.polygonscan.com/address/0x7B6E473f1CeB8b7100C9F7d58879e7211Bc48f32#code) |
-| DAI/USD      | [0x16984396EE0903782Ba8e6ebfA7DD356B0cA3841](https://testnet-zkevm.polygonscan.com/address/0x16984396EE0903782Ba8e6ebfA7DD356B0cA3841#code) |
-| LDO/USD      | [0x3aeF92049C9401094A9f75259430F4771143F0C3](https://testnet-zkevm.polygonscan.com/address/0x3aeF92049C9401094A9f75259430F4771143F0C3#code) |
-| LINK/USD    | [0x4EDdF05CfAd20f1E39ed4CB067bdfa831dAeA9fE](https://testnet-zkevm.polygonscan.com/address/0x4eddf05cfad20f1e39ed4cb067bdfa831daea9fe#code) |
-| MATIC/USD    | [0x06997AadB30d51eAdBAA7836f7a0F177474fc235](https://testnet-zkevm.polygonscan.com/address/0x06997AadB30d51eAdBAA7836f7a0F177474fc235#code) |
-| RETH/USD    | [0xEff79d34f24Bb36eD8FB6c4CbaD5De293fdCf66F](https://testnet-zkevm.polygonscan.com/address/0xEff79d34f24Bb36eD8FB6c4CbaD5De293fdCf66F#code) |
-| SDAI/USD    | [0xB6EE756124e88e12585981DdDa9E6E3bf3C4487D](https://testnet-zkevm.polygonscan.com/address/0xB6EE756124e88e12585981DdDa9E6E3bf3C4487D#code) |
-| SNX/USD    | [0x6Ab51f7E684923CE051e784D382A470b0fa834Be](https://testnet-zkevm.polygonscan.com/address/0x6Ab51f7E684923CE051e784D382A470b0fa834Be#code) |
-| SOL/USD    | [0x11ceEcca4d49f596E0Df781Af237CDE741ad2106](https://testnet-zkevm.polygonscan.com/address/0x11ceecca4d49f596e0df781af237cde741ad2106#code) |
-| UNI/USD    | [0xfE051Bc90D3a2a825fA5172181f9124f8541838c](https://testnet-zkevm.polygonscan.com/address/0xfE051Bc90D3a2a825fA5172181f9124f8541838c#code) |
-| USDC/USD    | [0xfef7a1Eb17A095E1bd7723cBB1092caba34f9b1C](https://testnet-zkevm.polygonscan.com/address/0xfef7a1eb17a095e1bd7723cbb1092caba34f9b1c#code) |
-| USDT/USD    | [0xF78A4e093Cd2D9F57Bb363Cc4edEBcf9bF3325ba](https://testnet-zkevm.polygonscan.com/address/0xF78A4e093Cd2D9F57Bb363Cc4edEBcf9bF3325ba#code) |
-| WBTC/USD    | [0x39C899178F4310705b12888886884b361CeF26C7](https://testnet-zkevm.polygonscan.com/address/0x39C899178F4310705b12888886884b361CeF26C7#code) |
+| BTC/USD       | [0xdD5232e76798BEACB69eC310d9b0864b56dD08dD](https://testnet-zkevm.polygonscan.com/address/0xdD5232e76798BEACB69eC310d9b0864b56dD08dD#code) |
+| CRV/USD       | [0x7B6E473f1CeB8b7100C9F7d58879e7211Bc48f32](https://testnet-zkevm.polygonscan.com/address/0x7B6E473f1CeB8b7100C9F7d58879e7211Bc48f32#code) |
+| DAI/USD       | [0x16984396EE0903782Ba8e6ebfA7DD356B0cA3841](https://testnet-zkevm.polygonscan.com/address/0x16984396EE0903782Ba8e6ebfA7DD356B0cA3841#code) |
+| ETH/BTC       | [0x4E866Ac929374096Afc2715C4e9c40D581A4067e](https://testnet-zkevm.polygonscan.com/address/0x4E866Ac929374096Afc2715C4e9c40D581A4067e#code) |
+| ETH/USD       | [0x90430C5b8045a1E2A0Fc4e959542a0c75b576439](https://testnet-zkevm.polygonscan.com/address/0x90430C5b8045a1E2A0Fc4e959542a0c75b576439#code) |
+| GNO/USD       | [0xBcC6BFFde7888A3008f17c88D5a5e5F0D7462cf9](https://testnet-zkevm.polygonscan.com/address/0xBcC6BFFde7888A3008f17c88D5a5e5F0D7462cf9#code) |
+| IBTA/USD      | [0xc52539EfbA58a521d69494D86fc47b9E71D32997](https://testnet-zkevm.polygonscan.com/address/0xc52539EfbA58a521d69494D86fc47b9E71D32997#code) |
+| LDO/USD       | [0x3aeF92049C9401094A9f75259430F4771143F0C3](https://testnet-zkevm.polygonscan.com/address/0x3aeF92049C9401094A9f75259430F4771143F0C3#code) |
+| LINK/USD      | [0x4EDdF05CfAd20f1E39ed4CB067bdfa831dAeA9fE](https://testnet-zkevm.polygonscan.com/address/0x4EDdF05CfAd20f1E39ed4CB067bdfa831dAeA9fE#code) |
+| MATIC/USD     | [0x06997AadB30d51eAdBAA7836f7a0F177474fc235](https://testnet-zkevm.polygonscan.com/address/0x06997AadB30d51eAdBAA7836f7a0F177474fc235#code) |
+| MKR/USD       | [0xE61A66f737c32d5Ac8cDea6982635B80447e9404](https://testnet-zkevm.polygonscan.com/address/0xE61A66f737c32d5Ac8cDea6982635B80447e9404#code) |
+| OP/USD        | [0x1ae491d618a667a44d48e0b0be2cc0cdbf269bc5](https://testnet-zkevm.polygonscan.com/address/0x1ae491d618a667a44d48e0b0be2cc0cdbf269bc5#code) |
+| RETH/USD      | [0xEff79d34f24Bb36eD8FB6c4CbaD5De293fdCf66F](https://testnet-zkevm.polygonscan.com/address/0xEff79d34f24Bb36eD8FB6c4CbaD5De293fdCf66F#code) |
+| SDAI/DAI      | [0xB6EE756124e88e12585981DdDa9E6E3bf3C4487D](https://testnet-zkevm.polygonscan.com/address/0xB6EE756124e88e12585981DdDa9E6E3bf3C4487D#code) |
+| SNX/USD       | [0x6Ab51f7E684923CE051e784D382A470b0fa834Be](https://testnet-zkevm.polygonscan.com/address/0x6Ab51f7E684923CE051e784D382A470b0fa834Be#code) |
+| SOL/USD       | [0x11ceEcca4d49f596E0Df781Af237CDE741ad2106](https://testnet-zkevm.polygonscan.com/address/0x11ceEcca4d49f596E0Df781Af237CDE741ad2106#code) |
+| UNI/USD       | [0xfE051Bc90D3a2a825fA5172181f9124f8541838c](https://testnet-zkevm.polygonscan.com/address/0xfE051Bc90D3a2a825fA5172181f9124f8541838c#code) |
+| USDC/USD      | [0xfef7a1Eb17A095E1bd7723cBB1092caba34f9b1C](https://testnet-zkevm.polygonscan.com/address/0xfef7a1Eb17A095E1bd7723cBB1092caba34f9b1C#code) |
+| USDT/USD      | [0xF78A4e093Cd2D9F57Bb363Cc4edEBcf9bF3325ba](https://testnet-zkevm.polygonscan.com/address/0xF78A4e093Cd2D9F57Bb363Cc4edEBcf9bF3325ba#code) |
+| WBTC/USD      | [0x39C899178F4310705b12888886884b361CeF26C7](https://testnet-zkevm.polygonscan.com/address/0x39C899178F4310705b12888886884b361CeF26C7#code) |
 | WSTETH/ETH    | [0x67E93d37B57747686F22f2F2f0a8aAd253199B38](https://testnet-zkevm.polygonscan.com/address/0x67E93d37B57747686F22f2F2f0a8aAd253199B38#code) |
 | WSTETH/USD    | [0x8Ba43F8Fa2fC13D7EEDCeb9414CDbB6643483C34](https://testnet-zkevm.polygonscan.com/address/0x8Ba43F8Fa2fC13D7EEDCeb9414CDbB6643483C34#code) |
-| YFI/USD    | [0x8Ba43F8Fa2fC13D7EEDCeb9414CDbB6643483C34](https://testnet-zkevm.polygonscan.com/address/0x16978358A8D6C7C8cA758F433685A5E8D988dfD4#code) |
+| YFI/USD       | [0x16978358A8D6C7C8cA758F433685A5E8D988dfD4](https://testnet-zkevm.polygonscan.com/address/0x16978358A8D6C7C8cA758F433685A5E8D988dfD4#code) |
 
 ## Smart Contract Addresses on Gnosis Network
 
-| Contract Name | Contract Address on Gnosis Network                                                                                                   |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Contract Name | Contract Address on Gnosis Network                                                                                          |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Self-kisser   | [0x0Dcc19657007713483A5cA76e6A7bbe5f56EA37d](https://gnosisscan.io/address/0x0Dcc19657007713483A5cA76e6A7bbe5f56EA37d#code) |
-| AAVE/USD       | [0xa38C2B5408Eb1DCeeDBEC5d61BeD580589C6e717](https://gnosisscan.io/address/0xa38C2B5408Eb1DCeeDBEC5d61BeD580589C6e717#code) |
-| ARB/USD      | [0x579BfD0581beD0d18fBb0Ebab099328d451552DD](https://gnosisscan.io/address/0x579bfd0581bed0d18fbb0ebab099328d451552dd#code) |
-| AVAX/USD    | [0x78C8260AF7C8D0d17Cf3BA91F251E9375A389688](https://gnosisscan.io/address/0x78C8260AF7C8D0d17Cf3BA91F251E9375A389688#code) |
+| AAVE/USD      | [0xa38C2B5408Eb1DCeeDBEC5d61BeD580589C6e717](https://gnosisscan.io/address/0xa38C2B5408Eb1DCeeDBEC5d61BeD580589C6e717#code) |
+| ARB/USD       | [0x579BfD0581beD0d18fBb0Ebab099328d451552DD](https://gnosisscan.io/address/0x579BfD0581beD0d18fBb0Ebab099328d451552DD#code) |
+| AVAX/USD      | [0x78C8260AF7C8D0d17Cf3BA91F251E9375A389688](https://gnosisscan.io/address/0x78C8260AF7C8D0d17Cf3BA91F251E9375A389688#code) |
 | BNB/USD       | [0x26EE3E8b618227C1B735D8D884d52A852410019f](https://gnosisscan.io/address/0x26EE3E8b618227C1B735D8D884d52A852410019f#code) |
-| BTC/USD    | [0x4B5aBFC0Fe78233b97C80b8410681765ED9fC29c](https://gnosisscan.io/address/0x4B5aBFC0Fe78233b97C80b8410681765ED9fC29c#code) |
-| CRV/USD     | [0xf29a932ae56bB96CcACF8d1f2Da9028B01c8F030](https://gnosisscan.io/address/0xf29a932ae56bb96ccacf8d1f2da9028b01c8f030#code) |
-| DAI/USD      | [0xa7aA6a860D17A89810dE6e6278c58EB21Fa00fc4](https://gnosisscan.io/address/0xa7aA6a860D17A89810dE6e6278c58EB21Fa00fc4#code) |
-| DSR/RATE      | [0x729af3A41AE9E707e7AE421569C4b9c632B66a0c](https://gnosisscan.io/address/0x729af3a41ae9e707e7ae421569c4b9c632b66a0c#code) |
-| ETH/BTC      | [0x1804969b296E89C1ddB1712fA99816446956637e](https://gnosisscan.io/address/0x1804969b296E89C1ddB1712fA99816446956637e#code) |
-| ETH/USD      | [0xc8A1F9461115EF3C1E84Da6515A88Ea49CA97660](https://gnosisscan.io/address/0xc8A1F9461115EF3C1E84Da6515A88Ea49CA97660#code) |
-| GNO/USD    | [0xA28dCaB66FD25c668aCC7f232aa71DA1943E04b8](https://gnosisscan.io/address/0xA28dCaB66FD25c668aCC7f232aa71DA1943E04b8#code) |
-| IBTA/USD    | [0x07487b0Bf28801ECD15BF09C13e32FBc87572e81](https://gnosisscan.io/address/0x07487b0Bf28801ECD15BF09C13e32FBc87572e81#code) |
-| LDO/USD    | [0xa53dc5B100f0e4aB593f2D8EcD3c5932EE38215E](https://gnosisscan.io/address/0xa53dc5B100f0e4aB593f2D8EcD3c5932EE38215E#code) |
-| LINK/USD    | [0xecB89B57A60ac44E06ab1B767947c19b236760c3](https://gnosisscan.io/address/0xecB89B57A60ac44E06ab1B767947c19b236760c3#code) |
-| MATIC/USD    | [0xa48c56e48A71966676d0D113EAEbe6BE61661F18](https://gnosisscan.io/address/0xa48c56e48A71966676d0D113EAEbe6BE61661F18#code) |
-| MKR/USD    | [0x67ffF0C6abD2a36272870B1E8FE42CC8E8D5ec4d](https://gnosisscan.io/address/0x67ffF0C6abD2a36272870B1E8FE42CC8E8D5ec4d#code) |
-| OP/USD    | [0xfadF055f6333a4ab435D2D248aEe6617345A4782](https://gnosisscan.io/address/0xfadf055f6333a4ab435d2d248aee6617345a4782#code) |
-| RETH/USD    | [0xEE02370baC10b3AC3f2e9eebBf8f3feA1228D263](https://gnosisscan.io/address/0xEE02370baC10b3AC3f2e9eebBf8f3feA1228D263#code) |
-| SDAI/DAI    | [0xD93c56Aa71923228cDbE2be3bf5a83bF25B0C491](https://gnosisscan.io/address/0xD93c56Aa71923228cDbE2be3bf5a83bF25B0C491#code) |
+| BTC/USD       | [0x4B5aBFC0Fe78233b97C80b8410681765ED9fC29c](https://gnosisscan.io/address/0x4B5aBFC0Fe78233b97C80b8410681765ED9fC29c#code) |
+| CRV/USD       | [0xf29a932ae56bB96CcACF8d1f2Da9028B01c8F030](https://gnosisscan.io/address/0xf29a932ae56bB96CcACF8d1f2Da9028B01c8F030#code) |
+| DAI/USD       | [0xa7aA6a860D17A89810dE6e6278c58EB21Fa00fc4](https://gnosisscan.io/address/0xa7aA6a860D17A89810dE6e6278c58EB21Fa00fc4#code) |
+| DSR/RATE      | [0x729af3A41AE9E707e7AE421569C4b9c632B66a0c](https://gnosisscan.io/address/0x729af3A41AE9E707e7AE421569C4b9c632B66a0c#code) |
+| ETH/BTC       | [0x1804969b296E89C1ddB1712fA99816446956637e](https://gnosisscan.io/address/0x1804969b296E89C1ddB1712fA99816446956637e#code) |
+| ETH/USD       | [0xc8A1F9461115EF3C1E84Da6515A88Ea49CA97660](https://gnosisscan.io/address/0xc8A1F9461115EF3C1E84Da6515A88Ea49CA97660#code) |
+| GNO/USD       | [0xA28dCaB66FD25c668aCC7f232aa71DA1943E04b8](https://gnosisscan.io/address/0xA28dCaB66FD25c668aCC7f232aa71DA1943E04b8#code) |
+| IBTA/USD      | [0x07487b0Bf28801ECD15BF09C13e32FBc87572e81](https://gnosisscan.io/address/0x07487b0Bf28801ECD15BF09C13e32FBc87572e81#code) |
+| LDO/USD       | [0xa53dc5B100f0e4aB593f2D8EcD3c5932EE38215E](https://gnosisscan.io/address/0xa53dc5B100f0e4aB593f2D8EcD3c5932EE38215E#code) |
+| LINK/USD      | [0xecB89B57A60ac44E06ab1B767947c19b236760c3](https://gnosisscan.io/address/0xecB89B57A60ac44E06ab1B767947c19b236760c3#code) |
+| MATIC/USD     | [0xa48c56e48A71966676d0D113EAEbe6BE61661F18](https://gnosisscan.io/address/0xa48c56e48A71966676d0D113EAEbe6BE61661F18#code) |
+| MKR/USD       | [0x67ffF0C6abD2a36272870B1E8FE42CC8E8D5ec4d](https://gnosisscan.io/address/0x67ffF0C6abD2a36272870B1E8FE42CC8E8D5ec4d#code) |
+| OP/USD        | [0xfadF055f6333a4ab435D2D248aEe6617345A4782](https://gnosisscan.io/address/0xfadF055f6333a4ab435D2D248aEe6617345A4782#code) |
+| RETH/USD      | [0xEE02370baC10b3AC3f2e9eebBf8f3feA1228D263](https://gnosisscan.io/address/0xEE02370baC10b3AC3f2e9eebBf8f3feA1228D263#code) |
+| SDAI/DAI      | [0xD93c56Aa71923228cDbE2be3bf5a83bF25B0C491](https://gnosisscan.io/address/0xD93c56Aa71923228cDbE2be3bf5a83bF25B0C491#code) |
+| SDAI/ETH      | [0x05aB94eD168b5d18B667cFcbbA795789C750D893](https://gnosisscan.io/address/0x05aB94eD168b5d18B667cFcbbA795789C750D893#code) |
 | SDAI/MATIC    | [0x2f0e0dE1F8c11d2380dE093ED15cA6cE07653cbA](https://gnosisscan.io/address/0x2f0e0dE1F8c11d2380dE093ED15cA6cE07653cbA#code) |
-| SOL/USD    | [0x4D1e6f39bbfcce8b471171b8431609b83f3a096D](https://gnosisscan.io/address/0x4D1e6f39bbfcce8b471171b8431609b83f3a096D#code) |
-| UNI/USD    | [0x2aFF768F5d6FC63fA456B062e02f2049712a1ED5](https://gnosisscan.io/address/0x2aFF768F5d6FC63fA456B062e02f2049712a1ED5#code) |
-| SNX/USD    | [0xD20f1eC72bA46b6126F96c5a91b6D3372242cE98](https://gnosisscan.io/address/0xD20f1eC72bA46b6126F96c5a91b6D3372242cE98#code) |
-| USDC/USD    | [0x1173da1811a311234e7Ab0A33B4B7B646Ff42aEC](https://gnosisscan.io/address/0x1173da1811a311234e7ab0a33b4b7b646ff42aec#code) |
-| USDT/USD    | [0x0bd446021Ab95a2ABd638813f9bDE4fED3a5779a](https://gnosisscan.io/address/0x0bd446021ab95a2abd638813f9bde4fed3a5779a#code) |
-| WBTC/USD    | [0xA7226d85CE5F0DE97DCcBDBfD38634D6391d0584](https://gnosisscan.io/address/0xa7226d85ce5f0de97dccbdbfd38634d6391d0584#code) |
-| WSTETH/USD    | [0xc9Bb81d3668f03ec9109bBca77d32423DeccF9Ab](https://gnosisscan.io/address/0xc9bb81d3668f03ec9109bbca77d32423deccf9ab#code) |
-| YFI/USD    | [0x0893EcE705639112C1871DcE88D87D81540D0199](https://gnosisscan.io/address/0x0893EcE705639112C1871DcE88D87D81540D0199#codee) |
+| SNX/USD       | [0xD20f1eC72bA46b6126F96c5a91b6D3372242cE98](https://gnosisscan.io/address/0xD20f1eC72bA46b6126F96c5a91b6D3372242cE98#code) |
+| SOL/USD       | [0x4D1e6f39bbfcce8b471171b8431609b83f3a096D](https://gnosisscan.io/address/0x4D1e6f39bbfcce8b471171b8431609b83f3a096D#code) |
+| UNI/USD       | [0x2aFF768F5d6FC63fA456B062e02f2049712a1ED5](https://gnosisscan.io/address/0x2aFF768F5d6FC63fA456B062e02f2049712a1ED5#code) |
+| USDC/USD      | [0x1173da1811a311234e7Ab0A33B4B7B646Ff42aEC](https://gnosisscan.io/address/0x1173da1811a311234e7Ab0A33B4B7B646Ff42aEC#code) |
+| USDT/USD      | [0x0bd446021Ab95a2ABd638813f9bDE4fED3a5779a](https://gnosisscan.io/address/0x0bd446021Ab95a2ABd638813f9bDE4fED3a5779a#code) |
+| WBTC/USD      | [0xA7226d85CE5F0DE97DCcBDBfD38634D6391d0584](https://gnosisscan.io/address/0xA7226d85CE5F0DE97DCcBDBfD38634D6391d0584#code) |
+| WSTETH/USD    | [0xc9Bb81d3668f03ec9109bBca77d32423DeccF9Ab](https://gnosisscan.io/address/0xc9Bb81d3668f03ec9109bBca77d32423DeccF9Ab#code) |
+| YFI/USD       | [0x0893EcE705639112C1871DcE88D87D81540D0199](https://gnosisscan.io/address/0x0893EcE705639112C1871DcE88D87D81540D0199#code) |
 
 ## General Setup Enquires
 


### PR DESCRIPTION
A lot of the addresses for the testnet oracles were out of date (particularly using version _1 of oracles instead of _2) so, with help from @teghnet,  I used a modified version of `./generate-contract-configs.sh` from oracle-suite to output the latest addresses.