### PR TITLE
Add references to the Dashboard for Testnet addresses

### DIFF
--- a/docs/Developers/Guides/whitelistAddress.md
+++ b/docs/Developers/Guides/whitelistAddress.md
@@ -35,7 +35,7 @@ $ cast send 0x0dcc19657007713483a5ca76e6a7bbe5f56ea37d "selfKiss(address, addres
 
 `0x0dcc19657007713483a5ca76e6a7bbe5f56ea37d` is the SelfKisser contract address.
 
-If you are looking for an Oracle address to quickly test out, feel free to use: Chronicle_ETH_USD_3	`0xdd6D76262Fd7BdDe428dcfCd94386EbAe0151603`.
+If you need an Oracle address for quick testing, you can use: `Chronicle_ETH_USD_3: 0xdd6D76262Fd7BdDe428dcfCd94386EbAe0151603`, or find a specific Oracle address using the [Chronicle Dashboard](https://chroniclelabs.org/dashboard).
 
 You can then verify your whitelist status by running:
 ```bash

--- a/docs/Developers/testnet.md
+++ b/docs/Developers/testnet.md
@@ -5,7 +5,10 @@ keywords: [testnet, Chronicle, addresses]
 ---
 
 # Testnet Addresses
-Here you can find the Oracles' smart contract addresses organized by chains:
+
+You can find the Oracles' smart contract addresses using the [Chronicle Dashboard](https://chroniclelabs.org/dashboard), by toggling the `<dev mode>` option located in the top right corner.
+
+Alternatively, you can also find here the addresses organized by chains:
 
 <details>
 <summary>Smart Contract Addresses on **Ethereum Sepolia**</summary>

--- a/docs/Developers/tutorials/Remix.md
+++ b/docs/Developers/tutorials/Remix.md
@@ -11,7 +11,7 @@ An example contract named `OracleReader.sol` allows you to consume Oracle data a
 
 :::info
 Addresses in this contract are hardcoded for the Sepolia testnet.
-For other supported networks, please check the [Dashboard](https://docs.chroniclelabs.org/).
+For other supported networks, please check the [Dashboard](https://chroniclelabs.org/dashboard). By toggling the `<dev mode>` option located in the top right corner, you can find the Oracles' addresses for different chains on Testnet.
 :::
 
 ```js


### PR DESCRIPTION
Add references to the Dashboard and the <dev mode> toggle for Testnet  Oracles' addresses