### PR TITLE
Move Brussels Guide to 'Previous'

### DIFF
--- a/docs/hackathons/Previous/eth-denver-hackathon.md
+++ b/docs/hackathons/Previous/eth-denver-hackathon.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
-# ETH Denver Hackathon Guide
+# 🇺🇸 ETH Denver Hackathon Guide
 
 Welcome to the ETH Denver Hackathon! This document serves as a guide for integrating Chronicle Oracles into your hackathon projects. Our team is here to assist you.
 

--- a/docs/hackathons/Previous/eth-global-brussels-hackathon.md
+++ b/docs/hackathons/Previous/eth-global-brussels-hackathon.md
@@ -158,7 +158,7 @@ Cast is a command-line interface (CLI) tool by the Foundry team to streamline yo
 
 Chronicle safeguards Oracle read functions with a whitelist, ensuring controlled access to critical data. However, the SelfKisser contract unfolds a possibility where you can whitelist yourself (or, as whimsically termed, "kiss") yourself.
 
-To kiss yourself, i.e., `msg.sender`, please check out the following guide, **[Getting Read Access to Contracts](../Developers/Guides/whitelistAddress.md)**.
+To kiss yourself, i.e., `msg.sender`, please check out the following guide, **[Getting Read Access to Contracts](../../Developers/Guides/whitelistAddress.md)**.
 
 **Please note that this is a mandatory step in ordr to be able to read from Chronicle Oracles.**
 :::

--- a/docs/hackathons/Previous/eth-global-istanbul-hackathon.md
+++ b/docs/hackathons/Previous/eth-global-istanbul-hackathon.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 2.5
+sidebar_position: 3
 ---
 
-# ETH Global Istanbul Guide
+# 🇹🇷 ETH Global Istanbul Guide
 
 Welcome to the ETHGlobal Istanbul Hackathon! This document serves as a guide for integrating Chronicle Oracles into your hackathon projects. Our team is here to assist you.
 

--- a/docs/hackathons/Previous/eth-lisbon-hackathon.md
+++ b/docs/hackathons/Previous/eth-lisbon-hackathon.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
-# ETH Lisbon Hackathon Guide
+# 🇵🇹 ETH Lisbon Hackathon Guide
 
 ![ETH Lisbon Hackathon](https://pbs.twimg.com/media/F43NCzgWMAAiQNi?format=png&name=large)
 

--- a/docs/hackathons/Previous/eth-warsaw-hackathon.md
+++ b/docs/hackathons/Previous/eth-warsaw-hackathon.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# ETH Warsaw Hackathon
+# 🇵🇱 ETH Warsaw Hackathon
 
 This document provides documentation for integrating Chronicle Oracles into their ETH Warsaw Hackathon projects.
 


### PR DESCRIPTION
Move Brussels Hackathon Guide to Previous folder:
- fix relative link 
- reorder guides and add country flag for each