### PR TITLE
Introduce Verified Asset Oracle

### DIFF
--- a/docs/Intro/dive/verifiedAssetOracle.md
+++ b/docs/Intro/dive/verifiedAssetOracle.md
@@ -1,11 +1,10 @@
 ---
 sidebar_position: 4
-description: Chronicle RWA Oracle
-keywords: [RWA Oracle, Real World Assets]
+description: Verified Asset Oracle
+keywords: [Verified Asset Oracle]
 ---
 
-# Chronicle RWA Oracle
-
+# Chronicle's Verified Asset Oracle
 ## What are RWAs?
 
 In the context of blockchain, Real-World Assets (RWAs) refer to physical assets and traditional financial instruments represented as digital assets on a blockchain network. These assets can range from assets such as real estate, commodities, art, and even intellectual property, to financial assets such as bonds, stocks, or ETFs . RWAs provide a bridge between traditional and decentralized finance opening up new opportunities for market inclusion, accessibility, and innovation.
@@ -18,8 +17,8 @@ In the context of blockchain, Real-World Assets (RWAs) refer to physical assets 
 />
 </div>
 
-## Chronicle Protocol Initial RWA Integration with M^0
+## Chronicle Protocol Initial Verified Asset Oracle Integration with M^0
 
-In August 2024, Chronicle launched its Real World Asset (RWA) Oracle with an integration with [M^0](https://www.m0.org/), a decentralized onchain protocol, as well as a set of off-chain standards and APIs, that allows multiple Minters to issue a fully fungible cryptodollar called $M.
+In August 2024, Chronicle launched its Verified Asset Oracle (formerly known as Real World Asset Oracle) with an integration with [M^0](https://www.m0.org/), a decentralized onchain protocol, as well as a set of off-chain standards and APIs, that allows multiple Minters to issue a fully fungible cryptodollar called $M.
 
 Chronicle Protocol onboarded as a validator, providing onchain information on the presence of offchain collateral (currently short term T-bills) used by Minters to generate $M cryptodollar. To learn more about this collaboration, please refer to the following [article](https://chroniclelabs.org/blog/m-0-and-chronicle-raising-the-standard-in-collateral-verification-with-the-rwa-oracle).

--- a/docs/Resources/FAQ/General.md
+++ b/docs/Resources/FAQ/General.md
@@ -37,7 +37,7 @@ GNO on Gnosis: [https://gnosisscan.io/address/0xA28dCaB66FD25c668aCC7f232aa71DA1
 The data originates from primary on-chain sources such as DEXes (e.g., Uniswap, dYdX, Balancer) and off-chain CEXes (e.g., Kraken, Binance, Coinbase). Only high-quality sources are used in Chronicle’s data models.
 
 ## What types of Oracles does Chronicle Protocol enable?
-In addition to the core price feed Oracles, two new products have been introduced: the [Yield Rate Oracle](https://chroniclelabs.org/blog/the-yield-rate-oracle) and the [Real World Asset (RWA) Oracle](https://chroniclelabs.org/blog/m-0-and-chronicle-raising-the-standard-in-collateral-verification-with-the-rwa-oracle).
+In addition to the core price feed Oracles, two new products have been introduced: the [Yield Rate Oracle](https://chroniclelabs.org/blog/the-yield-rate-oracle) and the [Verified Asset Oracle](https://chroniclelabs.org/blog/m-0-and-chronicle-raising-the-standard-in-collateral-verification-with-the-rwa-oracle) (formerly known as the Real World Asset Oracle).
 
 ## What is the difference between PUSH and PULL oracles?
 


### PR DESCRIPTION
Introduce Verified Asset Oracle
- replace all instances of RWA Oracle by Verified Asset Oracle 
- mention Verified Asset Oracle  is formerly known as RWA Oracle